### PR TITLE
Handle empty answers in analysis handler

### DIFF
--- a/internal/transport/http/handler/check_anketa.go
+++ b/internal/transport/http/handler/check_anketa.go
@@ -43,6 +43,13 @@ func NewAnalysisHandler(svc anketa.Analysis) stdhttp.HandlerFunc {
 		}
 
 		// валидация (минимальная)
+		if len(req.Answers) == 0 {
+			writeJSON(w, stdhttp.StatusBadRequest, errorResponse{
+				Error:   "validation_error",
+				Details: "answers must contain at least one element",
+			})
+			return
+		}
 		if strings.TrimSpace(req.Answers[0].QuestionText) == "" {
 			writeJSON(w, stdhttp.StatusBadRequest, errorResponse{
 				Error:   "validation_error",


### PR DESCRIPTION
## Summary
- guard against empty answers in the check_anketa HTTP handler before accessing the first element
- return distinct validation messages for missing answers and blank question_text values

## Testing
- GOPROXY=off go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68ca6edc068c8320813fefec6cdcdf41